### PR TITLE
[Feat] 양쪽에서 수정/삭제 시 즉각 업데이트 반영

### DIFF
--- a/Nower-iOS/Nower-iOS/AppDelegate.swift
+++ b/Nower-iOS/Nower-iOS/AppDelegate.swift
@@ -10,25 +10,20 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    var window: UIWindow?
-
-    func application(
-        _ application: UIApplication,
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-    ) -> Bool {
-
-        window = UIWindow(frame: UIScreen.main.bounds)
-        let VC = CalendarViewController()
-        let navVC = UINavigationController(rootViewController: VC)
-        window?.rootViewController = navVC
-        window?.makeKeyAndVisible()
-
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // 초기 설정 또는 iCloud 동기화 트리거
+        NSUbiquitousKeyValueStore.default.synchronize()
         return true
     }
 
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // ✅ 앱이 활성화될 때 무조건 iCloud 수동 동기화
-        NSUbiquitousKeyValueStore.default.synchronize()
-        print("✅ iCloud 수동 동기화 시도")
+    // MARK: UISceneSession Lifecycle
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession,
+                     options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // 해당 세션이 필요 없을 때 호출됨
     }
 }

--- a/Nower-iOS/Nower-iOS/Data/EventManager.swift
+++ b/Nower-iOS/Nower-iOS/Data/EventManager.swift
@@ -83,7 +83,7 @@ class EventManager {
         }
     }
 
-    private func loadTodos() {
+    func loadTodos() {
         guard let data = store.data(forKey: key),
                 let decoded = try? JSONDecoder().decode([TodoItem].self, from: data) else {
               todos = []

--- a/Nower-iOS/Nower-iOS/Info.plist
+++ b/Nower-iOS/Nower-iOS/Info.plist
@@ -1,5 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+        <key>UISceneConfigurations</key>
+        <dict>
+            <key>UIWindowSceneSessionRoleApplication</key>
+            <array>
+                <dict>
+                    <key>UISceneConfigurationName</key>
+                    <string>Default Configuration</string>
+                    <key>UISceneDelegateClassName</key>
+                    <string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+                </dict>
+            </array>
+        </dict>
+    </dict>
+</dict>
 </plist>

--- a/Nower-iOS/Nower-iOS/Presentation/Calendar/ViewController/CalendarViewController.swift
+++ b/Nower-iOS/Nower-iOS/Presentation/Calendar/ViewController/CalendarViewController.swift
@@ -23,6 +23,18 @@ class CalendarViewController: UIViewController {
         super.viewDidLoad()
         setupCollectionView()
         generateCalendar()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(icloudDidUpdate),
+            name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
+            object: NSUbiquitousKeyValueStore.default
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(forceSync),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
         NotificationCenter.default.addObserver(self, selector: #selector(todosUpdated), name: .init("TodosUpdated"), object: nil)
 
         calendarView.previousButton.addTarget(self, action: #selector(didTapPreviousMonth), for: .touchUpInside)
@@ -38,6 +50,19 @@ class CalendarViewController: UIViewController {
     private func setupCollectionView() {
         calendarView.collectionView.dataSource = self
         calendarView.collectionView.delegate = self
+    }
+
+    @objc private func icloudDidUpdate(notification: Notification) {
+        print("📥 iCloud 변경 감지됨 - 일정 새로고침")
+        EventManager.shared.loadTodos()
+        DispatchQueue.main.async {
+            self.calendarView.collectionView.reloadData()
+        }
+    }
+
+    @objc private func forceSync() {
+        NSUbiquitousKeyValueStore.default.synchronize()
+        print("🔄 수동 iCloud 동기화 요청됨")
     }
 
     // MARK: - 달력 생성
@@ -91,8 +116,11 @@ class CalendarViewController: UIViewController {
         isNextMonth = true
         generateCalendar()
     }
+
     @objc private func todosUpdated() {
-        calendarView.collectionView.reloadData()
+        DispatchQueue.main.async {
+            self.calendarView.collectionView.reloadData()
+        }
     }
 }
 
@@ -143,10 +171,10 @@ extension CalendarViewController: UICollectionViewDataSource {
             separator.backgroundColor = UIColor.lightGray.withAlphaComponent(0.3)
             cell.contentView.addSubview(separator)
 
-            separator.snp.makeConstraints { make in
-                make.leading.trailing.equalToSuperview()
-                make.bottom.equalToSuperview()
-                make.height.equalTo(0.5)
+            separator.snp.makeConstraints {
+                $0.leading.trailing.equalToSuperview()
+                $0.bottom.equalToSuperview()
+                $0.height.equalTo(0.5)
             }
         }
     }

--- a/Nower-iOS/Nower-iOS/Presentation/Common/DateCell.swift
+++ b/Nower-iOS/Nower-iOS/Presentation/Common/DateCell.swift
@@ -27,6 +27,14 @@ class DateCell: UICollectionViewCell {
     }()
     private let backgroundHighlightView = UIView()
 
+    private let moreLabel: UILabel = {
+        let label = UILabel()
+        label.text = ""
+        label.font = UIFont.systemFont(ofSize: 10)
+        label.textColor = .lightGray
+        return label
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupUI()
@@ -62,47 +70,47 @@ class DateCell: UICollectionViewCell {
     }
 
     func configure(day: Int, todos: [TodoItem], isToday: Bool, isSelected: Bool) {
-        dayLabel.text = "\(day)"
-        eventStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        DispatchQueue.main.async {
+            self.dayLabel.text = "\(day)"
+            self.eventStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
 
-        let maxVisibleEvents = 4
-        let limitedEvents = todos.prefix(maxVisibleEvents)
+            let maxVisibleEvents = 4
+            let limitedEvents = todos.prefix(maxVisibleEvents)
 
-        for todo in limitedEvents {
-            let capsule = EventCapsuleView()
-            capsule.configure(title: todo.text, color: AppColors.color(for: todo.colorName))
-            eventStackView.addArrangedSubview(capsule)
+            for todo in limitedEvents {
+                let capsule = EventCapsuleView()
+                capsule.configure(title: todo.text, color: AppColors.color(for: todo.colorName))
+                self.eventStackView.addArrangedSubview(capsule)
 
-            capsule.snp.makeConstraints {
-                $0.leading.trailing.equalToSuperview().inset(2)
+                capsule.snp.makeConstraints {
+                    $0.leading.trailing.equalToSuperview().inset(2)
+                }
             }
-        }
 
-        if todos.count > maxVisibleEvents {
-            let moreLabel = UILabel()
-            moreLabel.text = "+\(todos.count - maxVisibleEvents)개"
-            moreLabel.font = UIFont.systemFont(ofSize: 10)
-            moreLabel.textColor = .lightGray
-            eventStackView.addArrangedSubview(moreLabel)
-        }
+            if todos.count > maxVisibleEvents {
+                self.moreLabel.text = "+\(todos.count - maxVisibleEvents)개"
+                self.eventStackView.addArrangedSubview(self.moreLabel)
+            }
 
-        backgroundHighlightView.backgroundColor = .clear
-        backgroundHighlightView.layer.borderWidth = 0
-        dayLabel.textColor = AppColors.textPrimary
+            self.dayLabel.textColor = AppColors.textPrimary
 
-        if isToday {
-            dayLabel.textColor = .systemBlue
-        }
+            if isToday {
+                self.dayLabel.textColor = .systemBlue
+            }
 
-        if isSelected {
-            backgroundHighlightView.backgroundColor = UIColor.systemGray4.withAlphaComponent(0.5)
+            if isSelected {
+                self.backgroundHighlightView.backgroundColor = UIColor.systemGray4.withAlphaComponent(0.5)
+            } else {
+                self.backgroundHighlightView.backgroundColor = .clear
+            }
         }
     }
 
     func configureEmpty() {
-        dayLabel.text = ""
-        backgroundHighlightView.backgroundColor = .clear
-        backgroundHighlightView.layer.borderWidth = 0
-        eventStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        DispatchQueue.main.async {
+            self.dayLabel.text = ""
+            self.eventStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+            self.backgroundHighlightView.backgroundColor = .clear
+        }
     }
 }

--- a/Nower-iOS/Nower-iOS/SceneDelegate.swift
+++ b/Nower-iOS/Nower-iOS/SceneDelegate.swift
@@ -1,0 +1,26 @@
+//
+//  SceneDelegate.swift
+//  Nower-iOS
+//
+//  Created by 신종원 on 4/17/25.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    func scene(_ scene: UIScene,
+               willConnectTo session: UISceneSession,
+               options connectionOptions: UIScene.ConnectionOptions) {
+
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = CalendarViewController()
+        self.window = window
+        window.makeKeyAndVisible()
+    }
+}
+


### PR DESCRIPTION
## 🔥 PR 제목 (Issue 번호 포함)
- [#7 ] 양쪽에서 수정/삭제 시 즉각 업데이트 반영

## Description
- 양쪽 다 일정 추가/수정/삭제 시 즉각 업데이트 가능

## Check List
- [X] 적절한 라벨 설정
- [X] `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## 📷 변경 후 스크린샷 (선택 사항)


## 🛠 테스트 방법
- mac쪽에서 일정 추가하거나 삭제 시 iOS쪽에 반영되는지 확인 (반대로도 확인)

## 📌 참고 사항